### PR TITLE
Clean up form script and remove default '%' for include/exclude

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,10 +93,16 @@ const REPO  = "name-suggestion-index";
 
 // ===== Tiny helpers =====
 const $ = id => document.getElementById(id);
-const form = $("nsi-form"), preview = $("preview"), tip = $("tip");
-const wikidataInput = $("wikidata"), displayNameInput = $("displayName"), wkStatus = $("wkStatus"), wkLabel = $("wkLabel"), notableEl = $("notable"), includeInput = $("include");
+const form = $("nsi-form");
+const preview = $("preview");
+const tip = $("tip");
+const wikidataInput = $("wikidata");
+const displayNameInput = $("displayName");
+const wkStatus = $("wkStatus");
+const wkLabel = $("wkLabel");
+const includeInput = $("include");
 
-const csv = s => (s||"%").split(",").map(x=>x.trim()).filter(Boolean);
+const csv = s => String(s ?? "").split(",").map(x => x.trim()).filter(Boolean);
 const withTrailingComma = s => s.replace(/}\s*$/, '},');
 
 // Build minimal NSI object, pruning empty bits
@@ -207,10 +213,8 @@ form.addEventListener("submit", e=>{
   const dataFileUrl = `https://github.com/${OWNER}/${REPO}/blob/main/data/brands/${firstTagKey}/${fileVal}.json`;
 
   let body = "```json\n" + withTrailingComma(JSON.stringify(obj, null, 2)) + "\n```";
-  const notes = [];
-  if (notableEl?.checked) notes.push("notable: yes");
-  notes.push(`data file: ${dataFileUrl}`);
-  body += "\n\n**Notes to editors**\n\nCreated with https://ga-kevin-codes.github.io/Suggest-A-Brand/\n" + notes.join("\n");
+  body += "\n\n**Notes to editors**\n\nCreated with https://ga-kevin-codes.github.io/Suggest-A-Brand/\n";
+  body += `data file: ${dataFileUrl}`;
 
   const url = new URL(`https://github.com/${OWNER}/${REPO}/issues/new`);
   url.searchParams.set("title", title);


### PR DESCRIPTION
### Motivation
- Make the form script clearer and more robust by splitting a long chained declaration, removing dead references, and fixing include/exclude parsing so blank fields are not interpreted as `%`.
- Ensure the generated NSI preview and issue payload use the intended fallback (`001`) when no include value is provided.

### Description
- Split the long `const` chain into single `const` declarations for readability and remove the unused `notable` element reference (updated `index.html`).
- Replace the CSV helper from ` (s||"%").split(",")...` to `String(s ?? "").split(",")...` so empty include/exclude values produce an empty array instead of `%`.
- Keep the `locationSet` fallback to `["001"]` when the include list is empty so previews and issue titles are correct.
- Simplify issue notes generation by removing the dead `notable` checkbox logic and appending the data file line directly.

### Testing
- Executed a Node-based parse/eval of the embedded script with `new Function(...)` which completed successfully and printed `JavaScript syntax OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e7150da04832a9662147da1adceda)